### PR TITLE
Handle force deletion of non-existant sets

### DIFF
--- a/ipset_example_test.go
+++ b/ipset_example_test.go
@@ -68,3 +68,11 @@ func ExampleDestroy() {
 	//Output:
 	// no such set: hash012
 }
+
+func ExampleForceDestroy() {
+	setname := "hash03"
+	if err := ForceDestroy(setname); err != nil {
+		log.Fatal(err)
+	}
+	//Output:
+}

--- a/ipset_linux.go
+++ b/ipset_linux.go
@@ -3,6 +3,7 @@ package ipset
 import (
 	"log"
 	"net"
+	"os"
 	"syscall"
 
 	"github.com/vishvananda/netlink/nl"
@@ -136,7 +137,7 @@ func (h *Handle) Destroy(setname string) error {
 
 func (h *Handle) ForceDestroy(setname string) error {
 	err := h.Destroy(setname)
-	if err != nil && err != ErrSetNotExist {
+	if err != nil && err != ErrSetNotExist && !os.IsNotExist(err) {
 		return err
 	}
 	return nil


### PR DESCRIPTION
ForceDestroy checks for ErrSetNotExist, but since the return status is only wrapped in IPSetError if it's a private ipset error, the failed destruction isn't detected. This adds a check for ENOENT as well, wrapped by os.IsNotExist().