### PR TITLE
Fix adding comment to entry

### DIFF
--- a/ipset_linux.go
+++ b/ipset_linux.go
@@ -203,10 +203,6 @@ func (h *Handle) addDel(nlCmd int, setname string, entry *Entry) error {
 	req := h.newRequest(nlCmd)
 	req.AddData(nl.NewRtAttr(IPSET_ATTR_SETNAME, nl.ZeroTerminated(setname)))
 
-	if entry.Comment != "" {
-		req.AddData(nl.NewRtAttr(IPSET_ATTR_COMMENT, nl.ZeroTerminated(entry.Comment)))
-	}
-
 	data := nl.NewRtAttr(IPSET_ATTR_DATA|int(nl.NLA_F_NESTED), nil)
 
 	if !entry.Replace {
@@ -215,6 +211,10 @@ func (h *Handle) addDel(nlCmd int, setname string, entry *Entry) error {
 
 	if entry.Name != "" {
 		data.AddChild(nl.NewRtAttr(IPSET_ATTR_NAME, nl.ZeroTerminated(entry.Name)))
+	}
+
+	if entry.Comment != "" {
+		data.AddChild(nl.NewRtAttr(IPSET_ATTR_COMMENT, nl.ZeroTerminated(entry.Comment)))
 	}
 
 	if entry.Timeout != nil {


### PR DESCRIPTION
Specifying the Comment field in Entry has no effect. Adding it as a child of the data struct like the other fields resolves the issue.