### PR TITLE
Set correct flag for replacing ipset entries

### DIFF
--- a/ipset_linux.go
+++ b/ipset_linux.go
@@ -205,10 +205,10 @@ func (h *Handle) addDel(nlCmd int, setname string, entry *Entry) error {
 
 	data := nl.NewRtAttr(IPSET_ATTR_DATA|int(nl.NLA_F_NESTED), nil)
 
-	if !entry.Replace {
-		req.Flags |= unix.NLM_F_EXCL
-	} else {
-		req.flags |= unix.NLM_F_REPLACE
+	req.Flags |= unix.NLM_F_EXCL
+
+	if entry.Replace {
+		req.Flags |= unix.NLM_F_REPLACE
 	}
 
 	if entry.Name != "" {

--- a/ipset_linux.go
+++ b/ipset_linux.go
@@ -205,10 +205,10 @@ func (h *Handle) addDel(nlCmd int, setname string, entry *Entry) error {
 
 	data := nl.NewRtAttr(IPSET_ATTR_DATA|int(nl.NLA_F_NESTED), nil)
 
-	req.Flags |= unix.NLM_F_EXCL
-
 	if entry.Replace {
 		req.Flags |= unix.NLM_F_REPLACE
+	} else {
+		req.Flags |= unix.NLM_F_EXCL
 	}
 
 	if entry.Name != "" {

--- a/ipset_linux.go
+++ b/ipset_linux.go
@@ -207,6 +207,8 @@ func (h *Handle) addDel(nlCmd int, setname string, entry *Entry) error {
 
 	if !entry.Replace {
 		req.Flags |= unix.NLM_F_EXCL
+	} else {
+		req.flags |= unix.NLM_F_REPLACE
 	}
 
 	if entry.Name != "" {


### PR DESCRIPTION
Currently the flag sent to replace ipset entries is incorrect. 

Here's an example use case:
1. Create an ipset with `timeout 0` so that entries support timeouts
2. Add an entry to the ipset with a timeout of 60 (1min)
3. Try to add the same entry but with `Replace: true`

The expected result is that the timeout is refreshed as per the [manpage](https://ipset.netfilter.org/ipset.man.html):
>
> The timeout value of already added elements can be changed by re-adding the element using the -exist option
>

This doesn't happen though. Instead, you get this error:
```
%!(EXTRA ipset.IPSetError=exist)
```

With my changes, the `NLM_F_REPLACE` flag is passed when `Replace` is set to true, and this causes the ipset entries timeout to get refreshed.

Note that I didn't update the code for creating ipsets to pass the same flag as I don't think that's supported or needed.