### PR TITLE
Load ipset kernel modules when create misses set type

### DIFF
--- a/ipset_linux.go
+++ b/ipset_linux.go
@@ -125,7 +125,18 @@ func (h *Handle) Create(setname, typename string, options CreateOptions) error {
 
 	req.AddData(data)
 	_, err := ipsetExecute(req)
+	if isMissingIPSetModuleError(err) {
+		if loadErr := loadIPSetKernelModules(typename); loadErr != nil {
+			log.Printf("failed to load ipset kernel modules for type %q: %v", typename, loadErr)
+		} else {
+			_, err = ipsetExecute(req)
+		}
+	}
 	return err
+}
+
+func isMissingIPSetModuleError(err error) bool {
+	return err == ErrInvalidType || err == ErrSetNotExist || err == syscall.ENOENT
 }
 
 func (h *Handle) Destroy(setname string) error {

--- a/module_linux.go
+++ b/module_linux.go
@@ -1,0 +1,47 @@
+package ipset
+
+import (
+	"os/exec"
+)
+
+var loadKernelModule = func(name string) error {
+	return exec.Command("modprobe", name).Run()
+}
+
+var ipsetTypeModules = map[string]string{
+	TypeListSet: "ip_set_list_set",
+
+	TypeHashMac:        "ip_set_hash_mac",
+	TypeHashIPMac:      "ip_set_hash_ipmac",
+	TypeHashNetIface:   "ip_set_hash_netiface",
+	TypeHashNetPort:    "ip_set_hash_netport",
+	TypeHashNetPortNet: "ip_set_hash_netportnet",
+	TypeHashNetNet:     "ip_set_hash_netnet",
+	TypeHashNet:        "ip_set_hash_net",
+	TypeHashIPPortNet:  "ip_set_hash_ipportnet",
+	TypeHashIPPortIP:   "ip_set_hash_ipportip",
+	TypeHashIPMark:     "ip_set_hash_ipmark",
+	TypeHashIPPort:     "ip_set_hash_ipport",
+	TypeHashIP:         "ip_set_hash_ip",
+
+	TypeBitmapPort:  "ip_set_bitmap_port",
+	TypeBitmapIPMac: "ip_set_bitmap_ipmac",
+	TypeBitmapIP:    "ip_set_bitmap_ip",
+}
+
+func ipsetKernelModules(typename string) []string {
+	modules := []string{"ip_set"}
+	if module, ok := ipsetTypeModules[typename]; ok {
+		modules = append(modules, module)
+	}
+	return modules
+}
+
+func loadIPSetKernelModules(typename string) error {
+	for _, module := range ipsetKernelModules(typename) {
+		if err := loadKernelModule(module); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/module_linux_test.go
+++ b/module_linux_test.go
@@ -1,0 +1,138 @@
+package ipset
+
+import (
+	"syscall"
+	"testing"
+)
+
+func TestIPSetKernelModules(t *testing.T) {
+	tests := []struct {
+		name     string
+		typename string
+		want     []string
+	}{
+		{
+			name:     "hash mac",
+			typename: TypeHashMac,
+			want:     []string{"ip_set", "ip_set_hash_mac"},
+		},
+		{
+			name:     "hash ip mac",
+			typename: TypeHashIPMac,
+			want:     []string{"ip_set", "ip_set_hash_ipmac"},
+		},
+		{
+			name:     "hash net iface",
+			typename: TypeHashNetIface,
+			want:     []string{"ip_set", "ip_set_hash_netiface"},
+		},
+		{
+			name:     "hash net port",
+			typename: TypeHashNetPort,
+			want:     []string{"ip_set", "ip_set_hash_netport"},
+		},
+		{
+			name:     "hash net",
+			typename: TypeHashNet,
+			want:     []string{"ip_set", "ip_set_hash_net"},
+		},
+		{
+			name:     "hash net port net",
+			typename: TypeHashNetPortNet,
+			want:     []string{"ip_set", "ip_set_hash_netportnet"},
+		},
+		{
+			name:     "hash net net",
+			typename: TypeHashNetNet,
+			want:     []string{"ip_set", "ip_set_hash_netnet"},
+		},
+		{
+			name:     "hash ip port net",
+			typename: TypeHashIPPortNet,
+			want:     []string{"ip_set", "ip_set_hash_ipportnet"},
+		},
+		{
+			name:     "hash ip port ip",
+			typename: TypeHashIPPortIP,
+			want:     []string{"ip_set", "ip_set_hash_ipportip"},
+		},
+		{
+			name:     "hash ip mark",
+			typename: TypeHashIPMark,
+			want:     []string{"ip_set", "ip_set_hash_ipmark"},
+		},
+		{
+			name:     "hash ip port",
+			typename: TypeHashIPPort,
+			want:     []string{"ip_set", "ip_set_hash_ipport"},
+		},
+		{
+			name:     "hash ip",
+			typename: TypeHashIP,
+			want:     []string{"ip_set", "ip_set_hash_ip"},
+		},
+		{
+			name:     "bitmap port",
+			typename: TypeBitmapPort,
+			want:     []string{"ip_set", "ip_set_bitmap_port"},
+		},
+		{
+			name:     "bitmap ip mac",
+			typename: TypeBitmapIPMac,
+			want:     []string{"ip_set", "ip_set_bitmap_ipmac"},
+		},
+		{
+			name:     "bitmap ip",
+			typename: TypeBitmapIP,
+			want:     []string{"ip_set", "ip_set_bitmap_ip"},
+		},
+		{
+			name:     "list set",
+			typename: TypeListSet,
+			want:     []string{"ip_set", "ip_set_list_set"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ipsetKernelModules(tt.typename)
+			if len(got) != len(tt.want) {
+				t.Fatalf("expected %d modules, got %d: %v", len(tt.want), len(got), got)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Fatalf("expected module %d to be %q, got %q", i, tt.want[i], got[i])
+				}
+			}
+		})
+	}
+}
+
+func TestIPSetKernelModulesUnknownType(t *testing.T) {
+	got := ipsetKernelModules("unknown:type")
+	if len(got) != 1 || got[0] != "ip_set" {
+		t.Fatalf("expected only base ip_set module for unknown type, got %v", got)
+	}
+}
+
+func TestIsMissingIPSetModuleError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "invalid type", err: ErrInvalidType, want: true},
+		{name: "netfilter family absent", err: ErrSetNotExist, want: true},
+		{name: "raw enoent", err: syscall.ENOENT, want: true},
+		{name: "set already exists", err: ErrSetExist, want: false},
+		{name: "nil", err: nil, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isMissingIPSetModuleError(tt.err); got != tt.want {
+				t.Fatalf("expected %v, got %v", tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Retry ipset creation after loading the base ip_set module and the requested set type module when the kernel reports a missing type/module.
- Add an explicit ipset type to kernel module mapping for all currently supported set types.
- Log modprobe failures while preserving the original create error semantics.

## Test Plan
- GOOS=linux GOCACHE=/private/tmp/ipset-go-cache go test -c . -o /private/tmp/ipset-go.test
- git diff --check
